### PR TITLE
Allow client to override framed() check

### DIFF
--- a/spec/basic.js
+++ b/spec/basic.js
@@ -9,15 +9,40 @@ describe('framed', function() {
 		global.window = {};
 	});
 
-	it('should return true if D2L is undefined', function() {
-		var val = framed();
-		expect(val).to.be.true;
+	describe('window.D2L', function() {
+		it('should return true if is undefined', function() {
+			var val = framed();
+			expect(val).to.be.true;
+		});
+
+		it('should return false if is defined', function() {
+			global.window.D2L = {};
+
+			var val = framed();
+			expect(val).to.be.false;
+		});
 	});
 
-	it('should return false if D2L is defined', function() {
-		global.window.D2L = {};
+	describe('window.D2L.frau.forceFramed', function() {
+		it('should return true if is defined', function() {
+			global.window.D2L = {};
+			global.window.D2L.frau = { forceFramed: true };
 
-		var val = framed();
-		expect(val).to.be.false;
+			expect(framed()).to.be.true;
+		});
+
+		it('should return false if is false', function() {
+			global.window.D2L = {};
+			global.window.D2L.frau = { forceFramed: false };
+
+			expect(framed()).to.be.false;
+		});
+
+		it('should return false if is undefined', function() {
+			global.window.D2L = {};
+			global.window.D2L.frau = {};
+
+			expect(framed()).to.be.false;
+		});
 	});
 });

--- a/src/framed.js
+++ b/src/framed.js
@@ -1,5 +1,9 @@
 'use strict';
 
+function forceFramed(d2l) {
+	return !!(d2l && d2l.frau && d2l.frau.forceFramed);
+}
+
 module.exports = function framed() {
-	return !window.D2L;
+	return !window.D2L || forceFramed(window.D2L);
 };


### PR DESCRIPTION
Override the framed check by setting window.D2L.frau.forceFramed to true

Example:
```
window.D2L.frau = window.D2L.frau || {};
Object.assign(window.D2L.frau, { forceFramed: true });
```

This was change was made, because Polymer Free-range applications
located in an iframe using Brightspace components have `window.D2L` defined.

Example of component setting `window.D2L` (one of many):
https://github.com/Brightspace/d2l-polymer-behaviors-ui/blob/f667e1e2a11427d7476eef3071ea06809a9f44ca/d2l-dom.html#L75