### PR TITLE
check for presence of window.D2L.LP to determine if in LMS frame to a…

### DIFF
--- a/spec/basic.js
+++ b/spec/basic.js
@@ -14,10 +14,19 @@ describe('framed', function() {
 		expect(val).to.be.true;
 	});
 
-	it('should return false if D2L is defined', function() {
+	it('should return true if D2L is defined and D2L.LP is not defined', function() {
 		global.window.D2L = {};
+
+		var val = framed();
+		expect(val).to.be.true;
+	});
+
+	it('should return false if D2L.LP is defined', function() {
+		global.window.D2L = {};
+		global.window.D2L.LP = {};
 
 		var val = framed();
 		expect(val).to.be.false;
 	});
+
 });

--- a/src/framed.js
+++ b/src/framed.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = function framed () {
+module.exports = function framed() {
 	return !window.D2L || !window.D2L.LP;
 };

--- a/src/framed.js
+++ b/src/framed.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = function framed() {
-	return !window.D2L;
+module.exports = function framed () {
+	return !window.D2L || !window.D2L.LP;
 };


### PR DESCRIPTION
…llow web components with D2L behaviors to be used in iframe

When using web components like d2l-dropdown-ui and d2l-menu-ui in an iframe based FRA, I hit an issue where the frau-framed component thinks the app is running in the main LMS window, because the web components add behaviours to window.D2L.

So modified the framed check to also check for the presence of window.D2L.LP which doesn't exist in iframe FRAs.